### PR TITLE
Update Utils.tsx

### DIFF
--- a/src/Helper/Utils.tsx
+++ b/src/Helper/Utils.tsx
@@ -99,7 +99,7 @@ export const EmailRegex = new RegExp(
 
 export const MobileRegex = new RegExp(
   // eslint-disable-next-line no-useless-escape
-  /^((\+44\s?|0)7([45789]\d{2}|624)\s?\d{3}\s?\d{3})$/
+  /^((\+44\s?7|07)\d{3}\s?\d{3}\s?\d{3})$/
 );
 
 export const LandlineRegex = new RegExp(


### PR DESCRIPTION
The regex now validates any service provider code starting with '7', covering the range from 7000 to 7999. This change addresses the limitation of the previous pattern which only allowed specific codes.